### PR TITLE
Fix rcmdcheck note

### DIFF
--- a/R/format_commit_shas.R
+++ b/R/format_commit_shas.R
@@ -23,12 +23,12 @@ get_commits_df <- function(issue_number, owner = get_organization(), repo = get_
       message = stringr::str_remove_all(commit_log[[columns[[2]]]], "\n"),  # remove /n from message
       short_sha = stringr::str_extract(commit_log[[columns[[1]]]], "^.{1,7}"))
 
-  comit_log <- commit_log %>% dplyr::mutate(
+  commit_log <- commit_log %>% dplyr::mutate(
       display = glue::glue("{message} | {short_sha}")
     )
 
   commit_log <- commit_log %>%
-    dplyr::select(commit_log[[columns[[3]]]], commit_log[[columns[[1]]]], commit_log[[columns[[6]]]])
+    dplyr::select(columns[[3]], columns[[1]], columns[[6]])
 
 
   #last_row <- nrow(commit_log)

--- a/R/format_commit_shas.R
+++ b/R/format_commit_shas.R
@@ -19,13 +19,16 @@ get_commits_df <- function(issue_number, owner = get_organization(), repo = get_
   columns <- c("commit", "message", "date", "time", "short_sha", "display")
   commit_log <- commit_log %>%
     dplyr::mutate(
-      date = stringr::str_extract(.data[[columns[[4]]]], "^[\\w'-]+"),
-      message = stringr::str_remove_all(.data[[columns[[2]]]], "\n"),  # remove /n from message
-      short_sha = stringr::str_extract(.data[[columns[[1]]]], "^.{1,7}")) %>%
-    dplyr::mutate(
+      date = stringr::str_extract(commit_log[[columns[[4]]]], "^[\\w'-]+"),
+      message = stringr::str_remove_all(commit_log[[columns[[2]]]], "\n"),  # remove /n from message
+      short_sha = stringr::str_extract(commit_log[[columns[[1]]]], "^.{1,7}"))
+
+  comit_log <- commit_log %>% dplyr::mutate(
       display = glue::glue("{message} | {short_sha}")
-    ) %>%
-    dplyr::select(.data[[columns[[3]]]], .data[[columns[[1]]]], .data[[columns[[6]]]])
+    )
+
+  commit_log <- commit_log %>%
+    dplyr::select(commit_log[[columns[[3]]]], commit_log[[columns[[1]]]], commit_log[[columns[[6]]]])
 
 
   #last_row <- nrow(commit_log)


### PR DESCRIPTION
```
> devtools::check()
══ Documenting ════════════════════════════════════════════════════════════════════════════════════════════════
ℹ Updating ghqc.app documentation
ℹ Loading ghqc.app

══ Building ═══════════════════════════════════════════════════════════════════════════════════════════════════
Setting env vars:
• CFLAGS    : -Wall -pedantic -fdiagnostics-color=always
• CXXFLAGS  : -Wall -pedantic -fdiagnostics-color=always
• CXX11FLAGS: -Wall -pedantic -fdiagnostics-color=always
• CXX14FLAGS: -Wall -pedantic -fdiagnostics-color=always
• CXX17FLAGS: -Wall -pedantic -fdiagnostics-color=always
• CXX20FLAGS: -Wall -pedantic -fdiagnostics-color=always
── R CMD build ────────────────────────────────────────────────────────────────────────────────────────────────
✔  checking for file ‘/cluster-data/user-homes/jenna/Projects/ghqc.app/DESCRIPTION’ ...
─  preparing ‘ghqc.app’:
✔  checking DESCRIPTION meta-information
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
─  building ‘ghqc.app_0.0.0.9011.tar.gz’
   Warning: invalid uid value replaced by that for user 'nobody'
   Warning: invalid gid value replaced by that for user 'nobody'
   
══ Checking ═══════════════════════════════════════════════════════════════════════════════════════════════════
Setting env vars:
• _R_CHECK_CRAN_INCOMING_USE_ASPELL_           : TRUE
• _R_CHECK_CRAN_INCOMING_REMOTE_               : FALSE
• _R_CHECK_CRAN_INCOMING_                      : FALSE
• _R_CHECK_FORCE_SUGGESTS_                     : FALSE
• _R_CHECK_PACKAGES_USED_IGNORE_UNUSED_IMPORTS_: FALSE
• NOT_CRAN                                     : true
── R CMD check ────────────────────────────────────────────────────────────────────────────────────────────────
─  using log directory ‘/tmp/RtmpIBR1Ll/file3328f0717d70ac/ghqc.app.Rcheck’
─  using R version 4.4.1 (2024-06-14)
─  using platform: x86_64-pc-linux-gnu
─  R was compiled by
       gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
       GNU Fortran (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
─  running under: Ubuntu 22.04.5 LTS
─  using session charset: UTF-8
─  using options ‘--no-manual --as-cran’
✔  checking for file ‘ghqc.app/DESCRIPTION’
─  this is package ‘ghqc.app’ version ‘0.0.0.9011’
─  package encoding: UTF-8
✔  checking package namespace information
N  checking package dependencies (3.4s)
   Packages suggested but not available for checking: 'httptest', 'shinytest2'
   
   Imports includes 28 non-default packages.
   Importing from so many packages makes the package vulnerable to any of
   them becoming unavailable.  Move as many as possible to Suggests and
   use conditionally.
✔  checking if this is a source package
✔  checking if there is a namespace
✔  checking for executable files ...
✔  checking for hidden files and directories ...
✔  checking for portable file names
✔  checking for sufficient/correct file permissions
✔  checking serialization versions
✔  checking whether package ‘ghqc.app’ can be installed (3.7s)
✔  checking installed package size ...
✔  checking package directory ...
✔  checking for future file timestamps ...
✔  checking DESCRIPTION meta-information ...
✔  checking top-level files
✔  checking for left-over files
✔  checking index information
✔  checking package subdirectories ...
✔  checking code files for non-ASCII characters ...
✔  checking R files for syntax errors ...
✔  checking whether the package can be loaded (707ms)
✔  checking whether the package can be loaded with stated dependencies (579ms)
✔  checking whether the package can be unloaded cleanly (571ms)
✔  checking whether the namespace can be loaded with stated dependencies (606ms)
✔  checking whether the namespace can be unloaded cleanly (693ms)
✔  checking loading without being on the library search path (745ms)
✔  checking whether startup messages can be suppressed (1.4s)
✔  checking dependencies in R code (995ms)
✔  checking S3 generic/method consistency (779ms)
✔  checking replacement functions (625ms)
✔  checking foreign function calls (814ms)
✔  checking R code for possible problems (6.5s)
✔  checking Rd files ...
✔  checking Rd metadata ...
✔  checking Rd line widths ...
✔  checking Rd cross-references ...
✔  checking for missing documentation entries (583ms)
✔  checking for code/documentation mismatches (1.8s)
✔  checking Rd \usage sections (865ms)
✔  checking Rd contents ...
✔  checking for unstated dependencies in examples ...
─  checking examples ... NONE
✔  checking for unstated dependencies in ‘tests’ ...
─  checking tests ...
✔  Running ‘testthat.R’ (1.3s)
✔  checking for non-standard things in the check directory
✔  checking for detritus in the temp directory
   
   See
     ‘/tmp/RtmpIBR1Ll/file3328f0717d70ac/ghqc.app.Rcheck/00check.log’
   for details.
   
── R CMD check results ─────────────────────────────────────────────────────────────── ghqc.app 0.0.0.9011 ────
Duration: 29.2s

❯ checking package dependencies ... NOTE
  Packages suggested but not available for checking: 'httptest', 'shinytest2'
  
  Imports includes 28 non-default packages.
  Importing from so many packages makes the package vulnerable to any of
  them becoming unavailable.  Move as many as possible to Suggests and
  use conditionally.

0 errors ✔ | 0 warnings ✔ | 1 note ✖
```